### PR TITLE
Some improvements to Sensu checks registration

### DIFF
--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -7,6 +7,9 @@ from jsonschema import Draft4Validator
 from common import *
 from schemas import SensuHealthCheckSchema
 
+def create_sensu_check_definition_filename(service_id, check_id):
+    return '{0}-{1}.json'.format(service_id, check_id)
+
 class DeregisterOldSensuHealthChecks(DeploymentStage):
     def __init__(self):
         DeploymentStage.__init__(self, name='DeregisterOldSensuHealthChecks')
@@ -23,170 +26,161 @@ class DeregisterOldSensuHealthChecks(DeploymentStage):
                 if healthchecks is None:
                     return
                 for check_id, check in healthchecks.iteritems():
-                    service_check_filename = create_service_check_filename(deployment.service.id, check_id)
-                    definition_absolute_path = os.path.join(deployment.sensu['sensu_check_path'], service_check_filename)
-                    if not definition_absolute_path.endswith('.json'):
-                        definition_absolute_path += '.json'
-                    if os.path.exists(definition_absolute_path):
-                        os.remove(definition_absolute_path)
+                    check_definition_absolute_path = os.path.join(deployment.sensu['sensu_check_path'], create_sensu_check_definition_filename(deployment.service.id, check_id))
+                    if os.path.exists(check_definition_absolute_path):
+                        os.remove(check_definition_absolute_path)
 
 class RegisterSensuHealthChecks(DeploymentStage):
     def __init__(self):
         DeploymentStage.__init__(self, name='RegisterSensuHealthChecks')
+
     def _run(self, deployment):
-        def validate_checks(healthchecks, scripts_base_dir):
-            for check_id, check in healthchecks.iteritems():
-                validate_check(check_id, check)
-            ids_list = [id.lower() for id in healthchecks.keys()]
-            if len(ids_list) != len(set(ids_list)):
-                raise DeploymentError('Sensu health checks require unique ids (case insensitive)')
-
-            names_list = [tmp['name'] for tmp in healthchecks.values()]
-            if len(names_list) != len(set(names_list)):
-                raise DeploymentError('Sensu health checks require unique names (case insensitive)')
-
-            for check_id, check in healthchecks.iteritems():
-                if 'local_script' in check:
-                    if check['local_script'].startswith('/'):
-                        check['local_script'] = check['local_script'][1:]
-                        
-                    file_path = os.path.join(deployment.archive_dir, scripts_base_dir, check['local_script'])
-                    if not os.path.exists(file_path):
-                        raise DeploymentError('Couldn\'t find Sensu health check script in package with path: {0}'.format(os.path.join(scripts_base_dir, check['local_script'])))
-                elif 'server_script' in check:
-                    file_path = find_server_script(deployment.sensu['healthcheck_search_paths'], check['server_script'])
-                    if file_path == None:
-                        raise DeploymentError('Couldn\'t find server Sensu health check script: {0}\nPaths searched: {1}'.format(check['server_script'], deployment.sensu['healthcheck_search_paths']))
-
-        def validate_check(check_id, check):
-            Draft4Validator(SensuHealthCheckSchema).validate(check)
-            if not re.match(r'^[\w\.-]+$', check['name']):
-                raise DeploymentError('Health check name \'{0}\' doesn\'t match required Sensu name expression {1}'.format(check['name'], '/^[\w\.-]+$/'))
-            if 'local_script' in check and 'server_script' in check:
-                raise DeploymentError('Failed to register health check \'{0}\', you can use either \'local_script\' or \'server_script\', but not both.'.format(check_id))
-            if not ('local_script' in check or 'server_script' in check):
-                raise DeploymentError('Failed to register health check \'{0}\', you need at least one of: \'local_script\' or \'server_script\''.format(check_id))
-            if 'standalone' in check and 'aggregate' in check:
-                if check['standalone'] is True and check['aggregate'] is True:
-                    raise DeploymentError('Either standalone or aggregate can be True at the same time')
-                if check['standalone'] is False and check['aggregate'] is False:
-                    raise DeploymentError('Either standalone or aggregate can be False at the same time')
-
-        deployment.logger.info('Registering Sensu healthchecks.')
-        (healthchecks, scripts_base_dir) = find_healthchecks('sensu', deployment.archive_dir, deployment.appspec, deployment.logger)
-        if healthchecks is None:
+        deployment.logger.info('Registering Sensu checks.')
+        (sensu_checks, scripts_base_dir) = find_healthchecks('sensu', deployment.archive_dir, deployment.appspec, deployment.logger)
+        if sensu_checks is None:
+            deployment.logger.info('No Sensu checks to register.')
             return
+        RegisterSensuHealthChecks.validate_checks(sensu_checks, scripts_base_dir, deployment)
+        for check_id, check in sensu_checks.iteritems():
+            RegisterSensuHealthChecks.register_check(check_id, check, deployment)
 
-        validate_checks(healthchecks, scripts_base_dir)
-        for check_id, check in healthchecks.iteritems():
+    @staticmethod
+    def find_sensu_plugin(plugin_paths, script_filename):
+        for plugin_path in plugin_paths:
+            script_filepath = os.path.join(plugin_path, script_filename)
+            if os.path.exists(script_filepath):
+                return script_filepath
+        return None
 
-            if 'local_script' in check:
-                script_absolute_path = os.path.join(deployment.archive_dir, scripts_base_dir, check['local_script'])
+    @staticmethod
+    def generate_check_definition(check, script_absolute_path, instance_tags, logger):
+        override_notification_settings = check.get('override_notification_settings', None)
+        override_notification_email = check.get('override_notification_email', 'undef')
+        override_chat_channel = check.get('override_chat_channel', 'undef')
 
-                # Add execution permission to file
-                st = os.stat(script_absolute_path)
-                os.chmod(script_absolute_path, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
-            elif 'server_script' in check:
-                script_absolute_path = find_server_script(deployment.sensu['healthcheck_search_paths'], check['server_script'])
-            else:
-                raise DeploymentError('That should never happen - neither \'local_script\' nor \'server_script\' defined in health check')
-            
-            deployment.logger.debug('Healthcheck {0} full path: {1}'.format(check_id, script_absolute_path))
-            is_success = create_and_copy_check(deployment, script_absolute_path, check_id, check)
+        if override_notification_settings is None and (check.get('team', None) is not None):
+            logger.warning('\'team\' property is deprecated, please use \'override_notification_settings\' instead')
+            override_notification_settings = check.get('team')
+        if override_notification_email is 'undef' and (check.get('notification_email') is not None):
+            logger.warning('\'notification_email\' property is deprecated, please use \'override_notification_email\' instead')
+            override_notification_email = check.get('notification_email')
 
-            if not is_success:
-                raise DeploymentError('Failed to register Sensu health check \'{0}\''.format(check_id))
+        if override_notification_email is not 'undef':
+            override_notification_email = ','.join(override_notification_email)
+        if override_chat_channel is not 'undef':
+            override_chat_channel = ','.join(override_chat_channel)
+        
+        check_definition = { 
+            'checks': {
+                check['name']: {
+                    'aggregate': check.get('aggregate', False),
+                    'alert_after': check.get('alert_after', 600),
+                    'command': '{0} {1}'.format(script_absolute_path, check.get('script_arguments', '')).rstrip(),
+                    'handlers': [ 'default' ],
+                    'interval': check.get('interval'),
+                    'notification_email': override_notification_email,
+                    'occurrences': check.get('occurrences', 5),
+                    'page': check.get('paging_enabled', False),
+                    'project': check.get('project', False),
+                    'realert_every': check.get('realert_every', 30),
+                    'runbook': check.get('runbook', 'Please provide useful information to resolve alert'),
+                    'sla': check.get('sla', 'No SLA defined'),
+                    'slack_channel': override_chat_channel,
+                    'standalone': check.get('standalone', True),
+                    'subscribers': [ 'sensu-base' ],
+                    'tags': [],
+                    'team': override_notification_settings,
+                    'ticket': check.get('ticketing_enabled', False),
+                    'timeout': check.get('timeout', 120),
+                    'tip': check.get('tip', 'Fill me up with information')
+                }
+            }
+        }
 
-def create_service_check_filename(service_id, check_id):
-    return service_id + '-' + check_id
+        custom_instance_tags = {k:v for k,v in instance_tags.iteritems() if not k.startswith('aws:')}
+        for key, value in custom_instance_tags.iteritems():
+            check_definition['checks'][check['name']]['ttl_' + key.lower()] = value
 
-def find_server_script(paths, server_script):
-    for path in paths:
-        script_path = os.path.join(path, server_script)
-        if os.path.exists(script_path):
-            return script_path
-        if os.path.exists(script_path + '.json'):
-            return script_path + '.json'
-    return None
+        return check_definition
 
-def create_check_definition(deployment, script_path, check_id, check):
-    standalone = check.get('standalone', None)
-    aggregate = check.get('aggregate', None)
+    @staticmethod
+    def register_check(check_id, check, deployment):
+        if 'local_script' in check:
+            script_absolute_path = check['local_script']
+            deployment.logger.info('Setting mode on file: {0}'.format(script_absolute_path))
+            st = os.stat(script_path)
+            os.chmod(script_path, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        elif 'server_script' in check:
+            script_absolute_path = check['server_script']
+        else:
+            raise DeploymentError('Missing script property \'local_script\' nor \'server_script\' in check definition')
+        
+        deployment.logger.debug('Sensu check {0} script path: {1}'.format(check_id, script_absolute_path))
 
-    # If neither is defined, standalone should be true
-    if standalone is None and aggregate is None:
-        standalone = True
-        aggregate = False
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, script_absolute_path, deployment.instance_tags, deployment.logger)
+        check_definition_filename = create_sensu_check_definition_filename(deployment.service.id, check_id)
+        check_definition_absolute_path = os.path.join(deployment.sensu['sensu_check_path'], check_definition_filename)
+        is_success = RegisterSensuHealthChecks.write_check_definition_file(check_definition, check_definition_absolute_path, deployment)
+        if not is_success:
+            raise DeploymentError('Failed to register Sensu check \'{0}\''.format(check_id))  
 
-    if standalone is not None and aggregate is None:
-        aggregate = not standalone
-    elif aggregate is not None and standalone is None:
-        standalone = not aggregate
+    @staticmethod
+    def validate_checks(checks, scripts_base_dir, deployment):
+        for check_id, check in checks.iteritems():
+            RegisterSensuHealthChecks.validate_check_properties(check_id, check)
+            RegisterSensuHealthChecks.validate_check_script(check_id, check, scripts_base_dir, deployment.sensu['healthcheck_search_paths'])
+        RegisterSensuHealthChecks.validate_unique_ids(checks)
+        RegisterSensuHealthChecks.validate_unique_names(checks)
 
-    override_notification_settings = check.get('override_notification_settings', None)
-    override_notification_email = check.get('override_notification_email', None)
-    override_chat_channel = check.get('override_chat_channel', None)
+    @staticmethod
+    def validate_check_properties(check_id, check):
+        Draft4Validator(SensuHealthCheckSchema).validate(check)
+        if not re.match(r'^[\w\.-]+$', check['name']):
+            raise DeploymentError('Health check name \'{0}\' doesn\'t match required Sensu name expression {1}'.format(check['name'], '/^[\w\.-]+$/'))
+        if 'local_script' in check and 'server_script' in check:
+            raise DeploymentError('Failed to register health check \'{0}\', you can use either \'local_script\' or \'server_script\', but not both.'.format(check_id))
+        if not ('local_script' in check or 'server_script' in check):
+            raise DeploymentError('Failed to register health check \'{0}\', you need at least one of: \'local_script\' or \'server_script\''.format(check_id))
+        if 'standalone' in check and 'aggregate' in check:
+            if check['standalone'] is True and check['aggregate'] is True:
+                raise DeploymentError('Either standalone or aggregate can be True at the same time')
+            if check['standalone'] is False and check['aggregate'] is False:
+                raise DeploymentError('Either standalone or aggregate can be False at the same time')
 
-    if override_notification_settings is None and (check.get('team', None) is not None):
-        deployment.logger.warning('\'team\' property is depracated, please use \'override_notification_settings\' instead')
-        override_notification_settings = check.get('team')
-    if override_notification_email is None and (check.get('notification_email') is not None):
-        deployment.logger.warning('\'notification_email\' property is depracated, please use \'override_notification_email\' instead')
-        override_notification_email = check.get('notification_email')
+    @staticmethod
+    def validate_check_script(check_id, check, local_scripts_base_dir, deployment):
+        if 'local_script' in check:
+            if check['local_script'].startswith('/'):
+                check['local_script'] = check['local_script'][1:]
+            absolute_file_path = os.path.join(deployment.archive_dir, local_scripts_base_dir, check['local_script'])
+            if not os.path.exists(absolute_file_path):
+                raise DeploymentError('Couldn\'t find Sensu check script in package with path: {0}'.format(os.path.join(local_scripts_base_dir, check['local_script'])))
+            check['local_script'] = absolute_file_path
+        elif 'server_script' in check:
+            absolute_file_path = RegisterSensuHealthChecks.find_sensu_plugin(deployment.sensu['healthcheck_search_paths'], check['server_script'])
+            if absolute_file_path == None:
+                raise DeploymentError('Couldn\'t find Sensu plugin script: {0}\nPaths searched: {1}'.format(check['server_script'], deployment.sensu['healthcheck_search_paths']))
+            check['server_script'] = absolute_file_path
 
-    if override_notification_email is not None:
-        override_notification_email = ','.join(override_notification_email)
-    if override_chat_channel is not None:
-        override_chat_channel = ','.join(override_chat_channel)
-    
-    check_obj = {
-      'command': '{0} {1}'.format(script_path, check.get('script_arguments', '')).rstrip(),
-      'interval': check.get('interval'),
-      'occurrences': check.get('occurrences', 5),
-      'timeout': check.get('timeout', 120),
-      'alert_after': check.get('alert_after', 600),
-      'realert_every': check.get('realert_every', 30),
-      
-      'team': override_notification_settings,
-      'notification_email': override_notification_email,
-      'slack_channel': override_chat_channel,
+    @staticmethod
+    def validate_unique_ids(checks):
+        check_ids = [check_id.lower() for check_id in checks.keys()]
+        if len(check_ids) != len(set(check_ids)):
+            raise DeploymentError('Sensu check definitions require unique ids (case insensitive)')
 
-      'standalone': standalone,
-      'aggregate': aggregate,
+    @staticmethod
+    def validate_unique_names(checks):
+        check_names = [check['name'] for check in checks.values()]
+        if len(check_names) != len(set(check_names)):
+            raise DeploymentError('Sensu check definitions require unique names (case insensitive)')
 
-      'ticket': check.get('ticketing_enabled', False),
-      'page': check.get('paging_enabled', False),
-      'project': check.get('project', False),
-
-      'sla': check.get('sla', 'No SLA defined'),
-      'runbook': check.get('runbook', 'Needs information'),
-      'tip': check.get('tip', 'Fill me up with information')
-    }
-
-    custom_instance_tags = {k:v for k,v in deployment.instance_tags.iteritems() if not k.startswith('aws:')}
-    for key, value in custom_instance_tags.iteritems():
-        check_obj['ttl_' + key.lower()] = value
-
-    sensu_check = generate_sensu_check(check['name'], check_obj)
-    deployment.logger.debug('Generated Sensu check \'{0}\': \'{1}\''.format(check_id, sensu_check))
-    return sensu_check
-
-def create_and_copy_check(deployment, script_path, check_id, check):
-    check_definition = create_check_definition(deployment, script_path, check_id, check)
-    service_check_filename = create_service_check_filename(deployment.service.id, check_id)
-    definition_absolute_path = os.path.join(deployment.sensu['sensu_check_path'], service_check_filename)
-    if not definition_absolute_path.endswith('.json'):
-        definition_absolute_path += '.json'
-
-    with open(definition_absolute_path, 'w') as check_definition_file_descriptor:
-        check_definition_file_descriptor.write(json.dumps(check_definition))
-    deployment.logger.info('Copied Sensu health check \'{0}\' to checks directory \'{1}\''.format(check_id, definition_absolute_path))
-    return True
-
-def generate_sensu_check(check_name, obj):
-    obj['handlers'] = ['default']
-    obj['subscribers'] = ['sensu-base']
-    obj['tags'] = []
-    
-    content = {'checks':{check_name: obj}}
-    return content
+    @staticmethod
+    def write_check_definition_file(check_definition, check_definition_absolute_path, deployment):
+        try:
+            with open(check_definition_absolute_path, 'w') as check_definition_file:
+                check_definition_file.write(json.dumps(check_definition, sort_keys=True, indent=4, separators=(',', ': ')))
+            deployment.logger.info('Created Sensu check definition: {0}'.format(check_definition_absolute_path))
+            return True
+        except:
+            deployment.logger.exception(sys.exc_info()[1])
+            return False

--- a/tests/test_sensu_healthchecks.py
+++ b/tests/test_sensu_healthchecks.py
@@ -2,21 +2,11 @@
 
 import unittest
 from jsonschema import ValidationError
-from mock import MagicMock, Mock
+from mock import MagicMock, Mock, patch
 
 from .context import agent
 from agent import key_naming_convention
 from agent.deployment_stages import RegisterSensuHealthChecks, DeploymentError
-from agent.deployment_stages.sensu_healthchecks import create_and_copy_check, create_check_definition
-
-healthchecks = {
-    'check_failing': {
-        'type': 'script'
-    },
-    'check_2': {
-        'type': 'http'
-    }
-}
 
 class MockLogger:
   def __init__(self):
@@ -25,158 +15,153 @@ class MockLogger:
     self.debug = Mock()
     self.warning = Mock()
 
-class MockService:
-  def __init__(self):
-    self.id = 'test_service'
-
 class MockDeployment:
     def __init__(self):
         self.logger = MockLogger()
         self.archive_dir = ''
-        self.service = MockService()
         self.instance_tags = {
-            'Environment': 'local'
+            'Environment': 'local',
+            'Role': 'role',
+            'OwningCluster': 'cluster'
         }
         self.sensu = {
-            'sensu_check_path': 'test_sensu_check_path'
-        }
-        self.appspec = {
-            'healthchecks': healthchecks
-        }
-    def set_check(self, check_id, check):
-        self.appspec = {
-            'sensu_healthchecks': {
-                check_id: check
-            }
-        }
-    def set_checks(self, checks):
-        self.appspec = {
-            'sensu_healthchecks': checks
+            'healthcheck_search_paths' : [ 'sensu_plugins_path' ]
         }
 
-class TestHealthChecks(unittest.TestCase):
+class TestRegisterSensuHealthChecks(unittest.TestCase):
     def setUp(self):
         self.deployment = MockDeployment()
-        self.tested_fn = RegisterSensuHealthChecks()
         
-    def test_missing_name_field(self):
-        check = {
-        }
-        self.deployment.set_check('check_failing', check)
+    def test_validate_missing_name_property(self):
+        check = { }
         with self.assertRaisesRegexp(ValidationError, "'name' is a required property"):
-            self.tested_fn._run(self.deployment)
+            RegisterSensuHealthChecks.validate_check_properties('check_id', check)
 
-    def test_missing_interval_field(self):
+    def test_validate_missing_interval_property(self):
         check = {
             'name': 'Missing-interval'
         }
-        self.deployment.set_check('check_failing', check)
         with self.assertRaisesRegexp(ValidationError, "'interval' is a required property"):
-            self.tested_fn._run(self.deployment)
+            RegisterSensuHealthChecks.validate_check_properties('check_id', check)
 
-    def test_missing_script_field(self):
+    def test_validate_missing_script_property(self):
         check = {
             'name': 'Missing-interval',
             'interval': 10
         }
-        self.deployment.set_check('check_failing', check)
         with self.assertRaisesRegexp(DeploymentError, 'you need at least one of'):
-            self.tested_fn._run(self.deployment)
+            RegisterSensuHealthChecks.validate_check_properties('check_id', check)
 
-    def test_both_script_fields(self):
+    def test_validate_both_scripts_properties_provided(self):
         check = {
             'name': 'missing-interval',
             'interval': 10,
             'local_script': 'a',
             'server_script': 'b',
         }
-        self.deployment.set_check('check_failing', check)
         with self.assertRaisesRegexp(DeploymentError, "you can use either 'local_script' or 'server_script'"):
-            self.tested_fn._run(self.deployment)
+            RegisterSensuHealthChecks.validate_check_properties('check_id', check)
 
-    def test_case_insensitive_id_conflict(self):
+    def test_validate_name_does_not_match_regexp(self):
+        check = {
+            'name': 'missing http',
+            'local_script': 'a',
+            'interval': 10,
+        }
+        with self.assertRaisesRegexp(DeploymentError, 'match required Sensu name expression'):
+            RegisterSensuHealthChecks.validate_check_properties('check_id', check)
+
+    def test_validate_integer_type_properties(self):
+        check = {
+            'name': 'missing-http',
+            'local_script': 'a',
+            'team': 'some_team'
+        }
+        property_names = [ 'interval', 'realert_every', 'timeout', 'occurrences', 'refresh' ]
+        last_property_name = None
+        for property_name in property_names:
+            if last_property_name is not None:
+                check[property_name] = 10
+            check[property_name] = '10s'
+            last_property_name = property_name
+            with self.assertRaisesRegexp(ValidationError, "'{0}' is not of type 'number'".format(check[property_name])):
+                RegisterSensuHealthChecks.validate_check_properties('check_id', check)
+
+    def test_validate_override_notification_email_property(self):
+        check = {
+            'name': 'sensu-check1',
+            'local_script': 'foo.py',
+            'override_notification_email': ['foo', 'bar'],
+            'interval': 10
+        }
+        with self.assertRaisesRegexp(ValidationError, "'foo' does not match"):
+            RegisterSensuHealthChecks.validate_check_properties('check_id', check)
+
+    def test_validate_all_ids_unique(self):
         checks = {
             'check_1': {
                 'name': 'missing-http-1',
-                'local_script': 'a',
+                'local_script': 'script.sh',
                 'interval': 10
             },
             'cheCK_1': {
                 'name': 'missing-http-2',
-                'local_script': 'a',
+                'local_script': 'script.sh',
                 'interval': 10
             }
         }
-        self.deployment.set_checks(checks)
-        with self.assertRaisesRegexp(DeploymentError, 'health checks require unique ids'):
-            self.tested_fn._run(self.deployment)
+        with self.assertRaisesRegexp(DeploymentError, 'Sensu check definitions require unique ids'):
+            RegisterSensuHealthChecks.validate_unique_ids(checks)
 
-    def test_case_insensitive_name_conflict(self):
+    def test_validate_all_names_unique(self):
         checks = {
             'check_1': {
                 'name': 'missing-http',
-                'local_script': 'a',
+                'local_script': 'script.sh',
                 'interval': 10
             },
             'check_2': {
                 'name': 'missing-http',
-                'local_script': 'a',
+                'local_script': 'script.sh',
                 'interval': 10
             }
         }
-        self.deployment.set_checks(checks)
-        with self.assertRaisesRegexp(DeploymentError, 'health checks require unique names'):
-            self.tested_fn._run(self.deployment)
+        with self.assertRaisesRegexp(DeploymentError, 'Sensu check definitions require unique names'):
+            RegisterSensuHealthChecks.validate_unique_names(checks)
     
-    def test_name_regexp(self):
-        checks = {
-            'check_1': {
-                'name': 'missing http',
-                'local_script': 'a',
-                'interval': 10,
-            }
-        }
+    def test_validate_missing_local_script(self):
+        def file_exists(path):
+            return False
+        patcher = patch('os.path.exists')
+        mock = patcher.start()
+        mock.side_effect = file_exists
 
-        self.deployment.set_checks(checks)
-        with self.assertRaisesRegexp(DeploymentError, 'match required Sensu name expression'):
-            self.tested_fn._run(self.deployment)
-
-    def test_missing_script(self):
         check = {
             'name': 'missing-http',
-            'local_script': 'a',
+            'local_script': 'script.sh',
             'interval': 10,
             'team': 'some_team'
         }
-        checks = {
-            'check_1': check
-        }
-        self.deployment.set_checks(checks)
-        with self.assertRaisesRegexp(DeploymentError, "Couldn't find Sensu health check script"):
-            self.tested_fn._run(self.deployment)
+        with self.assertRaisesRegexp(DeploymentError, "Couldn't find Sensu check script"):
+            RegisterSensuHealthChecks.validate_check_script('check_id', check, '/some/path', self.deployment)
 
-    def test_integer_type(self):
+    def test_validate_missing_sensu_plugin_script(self):
+        def file_exists(path):
+            return False
+        patcher = patch('os.path.exists')
+        mock = patcher.start()
+        mock.side_effect = file_exists
+
         check = {
             'name': 'missing-http',
-            'local_script': 'a',
+            'server_script': 'script.sh',
+            'interval': 10,
             'team': 'some_team'
         }
-        checks = {
-            'check_1': check
-        }
-        
-        params = ['interval', 'realert_every', 'timeout', 'occurrences', 'refresh']
-        last_param = None
-        for param in params:
-            if last_param is not None:
-                check[last_param] = 10
-            check[param] = '10s'
-            last_param = param
-            self.deployment.set_checks(checks)
-            with self.assertRaisesRegexp(ValidationError, "'{0}' is not of type 'number'".format(check[param])):
-                self.tested_fn._run(self.deployment)
+        with self.assertRaisesRegexp(DeploymentError, "Couldn't find Sensu plugin script"):
+            RegisterSensuHealthChecks.validate_check_script('check_id', check, None, self.deployment)
 
-    def test_warn_on_old_property(self):
+    def test_warning_deprecated_properties(self):
         check = {
             'name': 'sensu-check1',
             'local_script': 'foo.py',
@@ -186,34 +171,11 @@ class TestHealthChecks(unittest.TestCase):
         checks = {
             'check_1': check
         }
-        self.deployment.set_checks(checks)
-        
-        definition = create_check_definition(self.deployment, 'test_path', 'test_check_id', check)
-        obj = definition['checks']['sensu-check1']
-        with self.assertRaises(DeploymentError):
-            self.tested_fn._run(self.deployment)
-        self.deployment.logger.warning.assert_called_with("'notification_email' property is depracated, please use 'override_notification_email' instead")
-        self.assertEqual(obj['notification_email'], 'foo@bar.com,bar@biz.uk')
+        definition = RegisterSensuHealthChecks.generate_check_definition(check, 'test_path', self.deployment.instance_tags, self.deployment.logger)
+        self.deployment.logger.warning.assert_called_with("'notification_email' property is deprecated, please use 'override_notification_email' instead")
+        self.assertEqual(definition['checks']['sensu-check1']['notification_email'], 'foo@bar.com,bar@biz.uk')
 
-    def test_emails(self):
-        check = {
-            'name': 'sensu-check1',
-            'local_script': 'foo.py',
-            'override_notification_email': ['foo', 'bar'],
-            'interval': 10
-        }
-        checks = {
-            'check_1': check
-        }
-        self.deployment.set_checks(checks)
-        
-        definition = create_check_definition(self.deployment, 'test_path', 'test_check_id', check)
-        obj = definition['checks']['sensu-check1']
-
-        with self.assertRaisesRegexp(ValidationError, "'foo' does not match"):
-            self.tested_fn._run(self.deployment)
-
-    def test_team(self):
+    def test_generate_check_definiton_with_valid_team_property(self):
         check = {
             'name': 'sensu-check1',
             'local_script': 'foo.py',
@@ -222,19 +184,13 @@ class TestHealthChecks(unittest.TestCase):
         checks = {
             'check_1': check
         }
-        self.deployment.set_checks(checks)
-        
-        definition = create_check_definition(self.deployment, 'test_path', 'sensu-check1', check)
-        obj = definition['checks']['sensu-check1']
-        self.assertEqual(obj['team'], None)
-        
-        # Should be transformed to lowercase
-        check['override_notification_settings'] = 'test_team1'
-        definition = create_check_definition(self.deployment, 'test_path', 'test_check_id', check)
-        obj = definition['checks']['sensu-check1']
-        self.assertEqual(obj['team'], 'test_team1')
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, 'test_path', self.deployment.instance_tags, self.deployment.logger)
+        self.assertEqual(check_definition['checks']['sensu-check1']['team'], None)
+        check['override_notification_settings'] = 'dietcode'
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, 'test_path', self.deployment.instance_tags, self.deployment.logger)
+        self.assertEqual(check_definition['checks']['sensu-check1']['team'], 'dietcode')
 
-    def test_splitting_arrays(self):
+    def test_generate_check_definiton_with_valid_list_of_emails_and_slack_channels(self):
         check = {
             'name': 'sensu-check1',
             'local_script': 'fuj.py',
@@ -245,16 +201,11 @@ class TestHealthChecks(unittest.TestCase):
         checks = {
             'check_1': check
         }
-        self.deployment.set_checks(checks)
-        
-        definition = create_check_definition(self.deployment, 'test_path', 'sensu-check1', check)
-        obj = definition['checks']['sensu-check1']
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, 'test_path', self.deployment.instance_tags, self.deployment.logger)
+        self.assertEqual(check_definition['checks']['sensu-check1']['notification_email'], 'email1@ble.pl,email2@ble.pl')
+        self.assertEqual(check_definition['checks']['sensu-check1']['slack_channel'], 'channel1,channel2')
 
-        # Note: we rewrite these property names for Sensu JSON (eg. override_chat_channel -> slack_channel)
-        self.assertEqual(obj['notification_email'], 'email1@ble.pl,email2@ble.pl')
-        self.assertEqual(obj['slack_channel'], 'channel1,channel2')
-
-    def test_defaults(self):
+    def test_generate_check_definiton_with_default_values(self):
         check = {
             'name': 'sensu-check1',
             'local_script': 'foo.py',
@@ -263,15 +214,36 @@ class TestHealthChecks(unittest.TestCase):
         checks = {
             'check_1': check
         }
-        self.deployment.set_checks(checks)
-        
-        definition = create_check_definition(self.deployment, 'test_path', 'test_check_id', check)
-        obj = definition['checks']['sensu-check1']
-        self.assertEqual(obj['alert_after'], 600)
-        self.assertEqual(obj['realert_every'], 30)
-        self.assertEqual(obj['notification_email'], None)
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, 'test_path', self.deployment.instance_tags, self.deployment.logger)
+        self.assertEqual(check_definition['checks']['sensu-check1']['aggregate'], False)
+        self.assertEqual(check_definition['checks']['sensu-check1']['alert_after'], 600)
+        self.assertEqual(check_definition['checks']['sensu-check1']['handlers'], [ 'default' ])
+        self.assertEqual(check_definition['checks']['sensu-check1']['notification_email'], 'undef')
+        self.assertEqual(check_definition['checks']['sensu-check1']['occurrences'], 5)
+        self.assertEqual(check_definition['checks']['sensu-check1']['page'], False)
+        self.assertEqual(check_definition['checks']['sensu-check1']['project'], False)
+        self.assertEqual(check_definition['checks']['sensu-check1']['realert_every'], 30)
+        self.assertEqual(check_definition['checks']['sensu-check1']['slack_channel'], 'undef')
+        self.assertEqual(check_definition['checks']['sensu-check1']['standalone'], True)
+        self.assertEqual(check_definition['checks']['sensu-check1']['subscribers'], [ 'sensu-base' ])
+        self.assertEqual(check_definition['checks']['sensu-check1']['ticket'], False)
+        self.assertEqual(check_definition['checks']['sensu-check1']['timeout'], 120)
 
-    def test_command_script_with_no_arguments(self):
+    def test_generate_check_definiton_with_instance_tags(self):
+        check = {
+            'name': 'sensu-check1',
+            'local_script': 'foo.py',
+            'interval': 10
+        }
+        checks = {
+            'check_1': check
+        }
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, 'test_path', self.deployment.instance_tags, self.deployment.logger)
+        self.assertEqual(check_definition['checks']['sensu-check1']['ttl_environment'], self.deployment.instance_tags['Environment'])
+        self.assertEqual(check_definition['checks']['sensu-check1']['ttl_owningcluster'], self.deployment.instance_tags['OwningCluster'])
+        self.assertEqual(check_definition['checks']['sensu-check1']['ttl_role'], self.deployment.instance_tags['Role'])
+ 
+    def test_generate_check_definiton_with_command_and_no_arguments(self):
         check = {
             'name': 'sensu-check1',
             'server_script': 'foo.py',
@@ -280,13 +252,10 @@ class TestHealthChecks(unittest.TestCase):
         checks = {
             'check_1': check
         }
-        self.deployment.set_checks(checks)
-        
-        definition = create_check_definition(self.deployment, check['server_script'], 'test_check_id', check)
-        obj = definition['checks']['sensu-check1']
-        self.assertEqual(obj['command'], 'foo.py')
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment.instance_tags, self.deployment.logger)
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.py')
 
-    def test_command_script_with_arguments(self):
+    def test_generate_check_definiton_with_command_and_arguments(self):
         check = {
             'name': 'sensu-check1',
             'server_script': 'check-windows-service.ps1',
@@ -296,8 +265,5 @@ class TestHealthChecks(unittest.TestCase):
         checks = {
             'check_1': check
         }
-        self.deployment.set_checks(checks)
-        
-        definition = create_check_definition(self.deployment, check['server_script'], 'test_check_id', check)
-        obj = definition['checks']['sensu-check1']
-        self.assertEqual(obj['command'], 'check-windows-service.ps1 -ServiceName service_name')
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment.instance_tags, self.deployment.logger)
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'check-windows-service.ps1 -ServiceName service_name')


### PR DESCRIPTION
While testing the registration of Sensu checks, I have found a number of small inconsistencies that need fixing. Also the test coverage and general quality of the code left to be desired so I've refactored the code and improved unit tests/test coverage. 

This should help implementing the improvements discussed with the team.

Note that most of the bugs found are actually fixed in the unstable branch but have not yet made it to production. Please make sure that it done as soon as possible.

Bugs & Fixes:
* Discrepencies between wiki documentation for healthchecks.yml and what the code is actually doing. Updated wiki and code to be consistent.
* Applying correct default values to Sensu checks.
* `team`/`override_notification_settings` supposed to be a string for Sensu handlers to notify alerts via email/Slack/PagerDuty. However, validation bombs out unless an array is provided. 
* Pretty printing in check definition JSON file to help with troubleshooting.
* Some code cleanup to improve ease of maintenance/testing.
* Improve test coverage of the whole Sensu check registration feature.