### PR TITLE
Write dynamic package info based on build branch

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -38,6 +38,10 @@ function CreateChocolateyPackage {
     $NuspecFile = @(Get-Item $OutputDirectory\package.nuspec)
     $Nuspec = [xml] (Get-Content $NuspecFile)
     $Nuspec.package.metadata.version = $Version
+    $Nuspec.package.metadata.id = $PackageId
+    $Nuspec.package.metadata.title = $PackageId
+    $Nuspec.package.metadata.summary = $PackageId
+    $Nuspec.package.metadata.tags = $PackageId
     $Nuspec.Save($NuspecFile)
 
     Write-Host "Packaging deployment agent code into a single executable..."

--- a/windows/chocolatey/package.nuspec
+++ b/windows/chocolatey/package.nuspec
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>ttl-consul-deployment-agent-master</id>
-    <title>ttl-consul-deployment-agent-master</title>
+    <id />
+    <title />
     <version />
     <authors>Trainline</authors>
     <owners>Trainline</owners>
-    <summary>ttl-consul-deployment-agent-master</summary>
+    <summary />
     <description>Agent listening to configuration changes in Consul and deploying services.</description>
     <projectUrl>https://github.com/trainline/consul-deployment-agent</projectUrl>
-    <tags>ttl-consul-deployment-agent-master</tags>
+    <tags />
     <copyright />
     <licenseUrl>https://github.com/trainline/consul-deployment-agent</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
This change fixes the build issue of incorrectly named chocolatey packages when building non-master branches.