### PR TITLE
Provide slice info to healthcheck scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ coverage.xml
 *.mo
 *.pot
 
+# Swap
+*.swp
+*.swo
+
 # Django stuff:
 *.log
 local_settings.py

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -54,8 +54,8 @@ class RegisterSensuHealthChecks(DeploymentStage):
     def generate_check_definition(check, script_absolute_path, deployment):
         instance_tags = deployment.instance_tags
         logger = deployment.logger
-        deployment_slice = deployment.service.get('slice', 'none')
-        if deployment_slice.lower() == 'none':
+        deployment_slice = deployment.service.get('slice', 'none').lower()
+        if deployment_slice == 'none':
             deployment_slice = None
 
         override_notification_settings = check.get('override_notification_settings', None)

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -64,8 +64,13 @@ class RegisterSensuHealthChecks(DeploymentStage):
                 command = '{0} "{1}"'.format('powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file', script_absolute_path)
             else:
                 command = script_absolute_path
-            script_args = check.get('script_arguments')
-            script_args = ' '.join(filter(None, (script_args, deployment_slice)))
+            
+            script_args = check.get('script_arguments', '')
+            
+            # Append slice value for local scripts
+            if 'local_script' in check:
+                script_args = ' '.join(filter(None, (script_args, deployment_slice)))
+
             return '{0} {1}'.format(command, script_args).rstrip()
 
         def get_override_chat_channel():

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -55,8 +55,8 @@ class RegisterSensuHealthChecks(DeploymentStage):
         platform = deployment.platform
         instance_tags = deployment.instance_tags
         logger = deployment.logger
-        deployment_slice = deployment.service.get('slice', 'none').lower()
-        if deployment_slice == 'none':
+        deployment_slice = deployment.service.slice
+        if deployment_slice is not None and deployment_slice.lower() == 'none':
             deployment_slice = None
 
         def get_command():

--- a/agent/version.py
+++ b/agent/version.py
@@ -1,3 +1,3 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-semantic_version = '0.22.8'
+semantic_version = '0.22.9'

--- a/tests/test_consul_healthchecks.py
+++ b/tests/test_consul_healthchecks.py
@@ -1,8 +1,9 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
 import unittest
-from mock import Mock
+import os
 
+from mock import Mock, MagicMock, patch
 from agent.deployment_stages.common import DeploymentError
 from agent.deployment_stages.consul_healthchecks import RegisterConsulHealthChecks
 
@@ -14,6 +15,15 @@ healthchecks = {
         'type': 'http'
     }
 }
+
+class MockService(object):
+    slice = None
+
+    def __init__(self):
+        self.id = 'my-mock-service'
+
+    def set_slice(self, slice):
+        self.slice = slice
 
 class MockLogger(object):
     def __init__(self):
@@ -28,6 +38,8 @@ class MockDeployment(object):
         self.appspec = {
             'healthchecks': healthchecks
         }
+        self.service = MockService()
+
     def set_check(self, check_id, check):
         self.appspec = {
             'consul_healthchecks': {
@@ -104,5 +116,71 @@ class TestHealthChecks(unittest.TestCase):
         with self.assertRaisesRegexp(DeploymentError, 'health checks require unique names'):
             self.tested_fn._run(self.deployment)
 
+    @patch('os.stat')
+    @patch('os.chmod')
+    @patch('os.path.exists', return_value=True)
+    def test_script_check_registration(self, stat, chmod, exists):
+        checks = {
+            'test_check': self.create_check(True, 'test-script', 'test-script.py', '10')
+        }
+        self.deployment.set_checks(checks)
+        self.deployment.consul_api = MagicMock()
 
+        with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
+            self.tested_fn._run(self.deployment)
+            self.deployment.consul_api.register_script_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_check', 'test-script', 'test-script.py', '10')
 
+    @patch('os.stat')
+    @patch('os.chmod')
+    @patch('os.path.exists', return_value=True)
+    def test_script_check_registration_with_slice(self, stat, chmod, exists):
+        checks = {
+            'test_check': self.create_check(True, 'test-script', 'test-script.py', '10')
+        }
+        self.deployment.set_checks(checks)
+        self.deployment.service.set_slice('blue')
+        self.deployment.consul_api = MagicMock()
+
+        with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
+            self.tested_fn._run(self.deployment)
+            self.deployment.consul_api.register_script_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_check', 'test-script', 'test-script.py blue', '10')
+
+    @patch('os.stat')
+    @patch('os.chmod')
+    @patch('os.path.exists', return_value=True)
+    def test_script_http_registration(self, stat, chmod, exists):
+        checks = {
+            'test_http_check': self.create_check(False, 'test-http', 'http://acme.com/healthcheck', '20')
+        }
+        self.deployment.set_checks(checks)
+        self.deployment.consul_api = MagicMock()
+
+        with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
+            self.tested_fn._run(self.deployment)
+            self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_http_check', 'test-http', 'http://acme.com/healthcheck', '20')
+    
+    @patch('os.stat')
+    @patch('os.chmod')
+    @patch('os.path.exists', return_value=True)
+    def test_http_check_registration_with_slice(self, stat, chmod, exists):
+        checks = {
+            'test_http_check': self.create_check(False, 'test-http', 'http://acme.com/healthcheck', '20')
+        }
+        self.deployment.set_checks(checks)
+        self.deployment.service.set_slice('blue')
+        self.deployment.consul_api = MagicMock()
+
+        # Slice value should not affect http value
+        with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
+            self.tested_fn._run(self.deployment)
+            self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_http_check', 'test-http', 'http://acme.com/healthcheck', '20')
+    
+    def create_check(self, is_script, name, value, interval):
+        check = { 'name':name, 'interval':interval }
+        if is_script:
+            check['type'] = 'script'
+            check['script'] = value
+        else:
+            check['type'] = 'http'
+            check['http'] = value
+        return check

--- a/tests/test_consul_healthchecks.py
+++ b/tests/test_consul_healthchecks.py
@@ -1,7 +1,6 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
 import unittest
-import os
 
 from mock import Mock, MagicMock, patch
 from agent.deployment_stages.common import DeploymentError

--- a/tests/test_sensu_healthchecks.py
+++ b/tests/test_sensu_healthchecks.py
@@ -256,7 +256,18 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
         self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh')
     
-    def test_generate_linux_check_definition_with_command_and_slice_and_no_arguments(self):
+    def test_generate_linux_local_check_definition_with_command_and_slice_and_no_arguments(self):
+        check = {
+            'name': 'sensu-check1',
+            'local_script': 'foo.sh',
+            'interval': 10
+        }
+        self.deployment.platform = 'linux'
+        self.deployment.service.slice = 'green'
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['local_script'], self.deployment)
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh green')
+    
+    def test_generate_linux_server_check_definition_with_command_and_slice_and_no_arguments(self):
         check = {
             'name': 'sensu-check1',
             'server_script': 'foo.sh',
@@ -265,7 +276,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         self.deployment.platform = 'linux'
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh green')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh')
     
     def test_generate_linux_check_definition_with_command_and_arguments(self):
         check = {
@@ -278,7 +289,19 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
         self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh -o service_name')
 
-    def test_generate_linux_check_definition_with_command_and_slice_and_arguments(self):
+    def test_generate_linux_local_check_definition_with_command_and_slice_and_arguments(self):
+        check = {
+            'name': 'sensu-check1',
+            'local_script': 'foo.sh',
+            'script_arguments': '-o service_name',
+            'interval': 10
+        }
+        self.deployment.platform = 'linux'
+        self.deployment.service.slice = 'blue'
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['local_script'], self.deployment)
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh -o service_name blue')
+    
+    def test_generate_linux_server_check_definition_with_command_and_slice_and_arguments(self):
         check = {
             'name': 'sensu-check1',
             'server_script': 'foo.sh',
@@ -288,7 +311,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         self.deployment.platform = 'linux'
         self.deployment.service.slice = 'blue'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh -o service_name blue')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh -o service_name')
     
     def test_generate_windows_check_definition_with_command_and_no_arguments(self):
         check = {
@@ -309,7 +332,6 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
         self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "foo.ps1"')
     
-    
     def test_generate_windows_check_definition_with_command_and_arguments(self):
         check = {
             'name': 'sensu-check1',
@@ -320,7 +342,18 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
         self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
     
-    def test_generate_check_definition_with_command_and_arguments_and_slice(self):
+    def test_generate_local_check_definition_with_command_and_arguments_and_slice(self):
+        check = {
+            'name': 'sensu-check1',
+            'local_script': 'C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1',
+            'script_arguments': '-ServiceName service_name',
+            'interval': 10
+        }
+        self.deployment.service.slice = 'green'
+        check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['local_script'], self.deployment)
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name green')
+    
+    def test_generate_server_check_definition_with_command_and_arguments_and_slice(self):
         check = {
             'name': 'sensu-check1',
             'server_script': 'C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1',
@@ -329,4 +362,4 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name green')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')

--- a/tests/test_sensu_healthchecks.py
+++ b/tests/test_sensu_healthchecks.py
@@ -13,6 +13,12 @@ class MockLogger(object):
         self.debug = Mock()
         self.warning = Mock()
 
+class MockService(object):
+    slice = None
+
+    def set_slice(self, slice):
+        self.slice = slice
+
 class MockDeployment(object):
     def __init__(self):
         self.logger = MockLogger()
@@ -26,9 +32,7 @@ class MockDeployment(object):
         self.sensu = {
             'healthcheck_search_paths': ['sensu_plugins_path']
         }
-        self.service = {
-            
-        }
+        self.service = MockService()
 
 class TestRegisterSensuHealthChecks(unittest.TestCase):
     def setUp(self):
@@ -248,7 +252,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         self.deployment.platform = 'linux'
-        self.deployment.service['slice'] = 'none'
+        self.deployment.service.slice = 'none'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
         self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh')
     
@@ -259,7 +263,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         self.deployment.platform = 'linux'
-        self.deployment.service['slice'] = 'green'
+        self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
         self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh green')
     
@@ -282,7 +286,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         self.deployment.platform = 'linux'
-        self.deployment.service['slice'] = 'blue'
+        self.deployment.service.slice = 'blue'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
         self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'foo.sh -o service_name blue')
     
@@ -301,7 +305,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'server_script': 'foo.ps1',
             'interval': 10
         }
-        self.deployment.service['slice'] = 'none'
+        self.deployment.service.slice = 'none'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
         self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "foo.ps1"')
     
@@ -323,6 +327,6 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'script_arguments': '-ServiceName service_name',
             'interval': 10
         }
-        self.deployment.service['slice'] = 'green'
+        self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
         self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name green')


### PR DESCRIPTION
This change allows multi-tenanted blue/green services to simultaneously run healthchecks for both slices.

For sensu healthchecks, the slice name is added to the end of the `script_arguments` value. If `script_arguments` is empty, the slice name is the only value passed.

For consul `script` type checks, the slice name is passed as the only argument to the check script. Consul `http` checks do not receive the slice name.

In all cases, if there is no slice info (or the slice value is _'none'_), no argument is passed at all.