### PR TITLE
Remove old deployments

### DIFF
--- a/agent/deployment.py
+++ b/agent/deployment.py
@@ -30,13 +30,17 @@ class Deployment(object):
         self._is_success = self.logger = self._log_filename = self._log_filepath = self._report = self._report_key = None
         self.number_of_attempts = 0
         if self.platform == 'linux':
-            self.dir = os.path.join('/opt/consul-deployment-agent/deployments', self.service.id, self.id)
+            base_dir = '/opt/consul-deployment-agent/deployments'
+            self.dir = os.path.join(base_dir, self.service.id, self.id)
             if self.last_id is not None:
-                self.last_archive_dir = os.path.join('/opt/consul-deployment-agent/deployments', self.service.id, self.last_id, 'archive')
+                self.last_dir = os.path.join(base_dir, self.service.id, self.last_id)
+                self.last_archive_dir = os.path.join(self.last_dir, 'archive')
         else:
-            self.dir = os.path.join('C:\TLDeploy', self.id)
+            base_dir = 'C:\TLDeploy'
+            self.dir = os.path.join(base_dir, self.id)
             if self.last_id is not None:
-                self.last_archive_dir = os.path.join('C:\TLDeploy', self.last_id, 'archive')
+                self.last_dir = os.path.join(base_dir, self.last_id)
+                self.last_archive_dir = os.path.join(self.last_dir, 'archive')
         self.archive_dir = os.path.join(self.dir, 'archive')
 
     def __str__(self):

--- a/agent/deployment_stages/delete_previous_deployment_files.py
+++ b/agent/deployment_stages/delete_previous_deployment_files.py
@@ -10,8 +10,8 @@ class DeletePreviousDeploymentFiles(DeploymentStage):
         if deployment.last_id is None:
             deployment.logger.info('Skipping {0} stage as there is no previous deployment.'.format(self.name))
         else:
-            if os.path.isdir(deployment.last_archive_dir):
-                deployment.logger.info('Deleting directory of previous deployment {0}.'.format(deployment.last_archive_dir))
-                distutils.dir_util.remove_tree(deployment.last_archive_dir)
+            if os.path.isdir(deployment.last_dir):
+                deployment.logger.info('Deleting directory of previous deployment {0}.'.format(deployment.last_dir))
+                distutils.dir_util.remove_tree(deployment.last_dir)
             else:
-                deployment.logger.warning('The directory of last deployment doesn\'t exist {0}.'.format(deployment.last_archive_dir))
+                deployment.logger.warning('The directory of last deployment doesn\'t exist {0}.'.format(deployment.last_dir))

--- a/agent/version.py
+++ b/agent/version.py
@@ -1,3 +1,3 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-semantic_version = '0.22.9'
+semantic_version = '0.22.10'


### PR DESCRIPTION
This removes the entire directory of the last deployment rather than just the /archive sub-directory. Without this disks are filling up fast because the bundle.zip and /logs still remain. Those bundles are usually quite big. 5-10 deployments is enough to use up over a gigabyte of disk in some cases.

**Note:** Ideally we would clear away all directories which are not the latest successful deployment because, even with this PR, failed deployments will still remain.. But that's a larger change and I'm not familiar enough with this code. Suggested changes to this PR are more than welcome.