### PR TITLE
Safely handle invalid healthchecks.yml

### DIFF
--- a/agent/deployment_stages/common.py
+++ b/agent/deployment_stages/common.py
@@ -119,7 +119,7 @@ def find_healthchecks(check_type, archive_dir, appspec, logger):
 
 def wrap_script_command(script, platform):
     if platform == 'windows':
-        return 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "{0}"'.format(script)
+        return 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file {0}'.format(script)
     else:
         return script
 

--- a/agent/deployment_stages/common.py
+++ b/agent/deployment_stages/common.py
@@ -116,3 +116,10 @@ def find_healthchecks(check_type, archive_dir, appspec, logger):
         logger.info('No health checks found.')
     return (healthchecks, scripts_base_dir)
 
+
+def wrap_script_command(script, platform):
+    if platform == 'windows':
+        return 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "{0}"'.format(script)
+    else:
+        return script
+

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -2,7 +2,7 @@
 
 import json, os, re, stat, sys
 from jsonschema import Draft4Validator
-from .common import DeploymentError, DeploymentStage, find_healthchecks, get_previous_deployment_appspec
+from .common import DeploymentError, DeploymentStage, find_healthchecks, get_previous_deployment_appspec, wrap_script_command
 from .schemas import SensuHealthCheckSchema
 
 def create_sensu_check_definition_filename(service_id, check_id):
@@ -66,11 +66,7 @@ class RegisterSensuHealthChecks(DeploymentStage):
             deployment_slice = None
 
         def get_command():
-            if platform == 'windows':
-                command = '{0} "{1}"'.format('powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file', script_absolute_path)
-            else:
-                command = script_absolute_path
-            
+            command = wrap_script_command(script_absolute_path, platform)
             script_args = check.get('script_arguments', '')
             
             # Append slice value for local scripts

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -26,6 +26,7 @@ class DeregisterOldSensuHealthChecks(DeploymentStage):
                 for check_id, check in healthchecks.iteritems():
                     check_definition_absolute_path = os.path.join(deployment.sensu['sensu_check_path'], create_sensu_check_definition_filename(deployment.service.id, check_id))
                     if os.path.exists(check_definition_absolute_path):
+                        deployment.logger.info('Removing healthcheck: {0}'.format(check_definition_absolute_path))
                         os.remove(check_definition_absolute_path)
 
 class RegisterSensuHealthChecks(DeploymentStage):

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -21,13 +21,18 @@ class DeregisterOldSensuHealthChecks(DeploymentStage):
                 deployment.logger.warning('Previous deployment directory not found, id: {0}'.format(deployment.last_id))
             else:
                 (healthchecks, scripts_base_dir) = find_healthchecks('sensu', deployment.last_archive_dir, previous_appspec, deployment.logger)
+                deployment.logger.debug('Sensu healthchecks to remove: {0}{1}'.format(os.linesep, healthchecks))
                 if healthchecks is None:
+                    deployment.logger.warning('No sensu checks will be removed')
                     return
                 for check_id, check in healthchecks.iteritems():
+                    deployment.logger.debug('Looking for sensu check: {0}'.format(check_id))
                     check_definition_absolute_path = os.path.join(deployment.sensu['sensu_check_path'], create_sensu_check_definition_filename(deployment.service.id, check_id))
                     if os.path.exists(check_definition_absolute_path):
                         deployment.logger.info('Removing healthcheck: {0}'.format(check_definition_absolute_path))
                         os.remove(check_definition_absolute_path)
+                    else:
+                        deployment.logger.warning('Could not find file: {0}'.format(check_definition_absolute_path))
 
 class RegisterSensuHealthChecks(DeploymentStage):
     def __init__(self):

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -21,7 +21,7 @@ class DeregisterOldSensuHealthChecks(DeploymentStage):
                 deployment.logger.warning('Previous deployment directory not found, id: {0}'.format(deployment.last_id))
             else:
                 (healthchecks, scripts_base_dir) = find_healthchecks('sensu', deployment.last_archive_dir, previous_appspec, deployment.logger)
-                deployment.logger.debug('Sensu healthchecks to remove: {0}{1}'.format(os.linesep, healthchecks))
+                deployment.logger.debug('Sensu healthchecks to remove: {0}'.format(healthchecks))
                 if healthchecks is None:
                     deployment.logger.warning('No sensu checks will be removed')
                     return

--- a/agent/version.py
+++ b/agent/version.py
@@ -1,3 +1,3 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-semantic_version = '0.22.22'
+semantic_version = '0.22.23'

--- a/agent/version.py
+++ b/agent/version.py
@@ -1,3 +1,3 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-semantic_version = '0.22.23'
+semantic_version = '0.22.24'

--- a/agent/version.py
+++ b/agent/version.py
@@ -1,3 +1,3 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-semantic_version = '0.22.12'
+semantic_version = '0.22.13'

--- a/agent/version.py
+++ b/agent/version.py
@@ -1,3 +1,3 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-semantic_version = '0.22.13'
+semantic_version = '0.22.14'

--- a/agent/version.py
+++ b/agent/version.py
@@ -1,3 +1,3 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-semantic_version = '0.22.14'
+semantic_version = '0.22.22'

--- a/agent/version.py
+++ b/agent/version.py
@@ -1,3 +1,3 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-semantic_version = '0.22.11'
+semantic_version = '0.22.12'

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,7 +13,7 @@ class TestCommonDeploymentStageUtils(unittest.TestCase):
     @patch('yaml.safe_load', side_effect=yaml.scanner.ScannerError)
     def test_find_healtchecks_safely_handles_invalid_yaml(self, exists, mock_open, mock_safe_load):
         logger = MagicMock()
-        result = find_healthchecks('sensu', '', {}, logger)
+        (healthchecks, script_dir) = find_healthchecks('sensu', '', {}, logger)
         self.assertEqual(logger.error.mock_calls[0], call('healthchecks/sensu/healthchecks.yml contains invalid YAML'))
-        self.assertEqual(result[0], None)
+        self.assertEqual(healthchecks, None)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,19 @@
+# Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
+
+import unittest
+import yaml
+
+from mock import patch, call, MagicMock
+from agent.deployment_stages.common import find_healthchecks
+
+class TestCommonDeploymentStageUtils(unittest.TestCase):
+
+    @patch('os.path.exists', return_value=True)
+    @patch('agent.deployment_stages.common.open', return_value=True)
+    @patch('yaml.safe_load', side_effect=yaml.scanner.ScannerError)
+    def test_find_healtchecks_safely_handles_invalid_yaml(self, exists, mock_open, mock_safe_load):
+        logger = MagicMock()
+        result = find_healthchecks('sensu', '', {}, logger)
+        self.assertEqual(logger.error.mock_calls[0], call('healthchecks/sensu/healthchecks.yml contains invalid YAML'))
+        self.assertEqual(result[0], None)
+

--- a/tests/test_consul_healthchecks.py
+++ b/tests/test_consul_healthchecks.py
@@ -162,7 +162,7 @@ class TestHealthChecks(unittest.TestCase):
 
         with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
                 self.tested_fn._run(self.deployment)
-                self.deployment.consul_api.register_script_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_check', 'test-script', 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "test-script.ps1"', '10')
+                self.deployment.consul_api.register_script_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_check', 'test-script', 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file test-script.ps1', '10')
 
     @patch('os.stat')
     @patch('os.chmod')
@@ -178,7 +178,7 @@ class TestHealthChecks(unittest.TestCase):
 
         with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
             self.tested_fn._run(self.deployment)
-            self.deployment.consul_api.register_script_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_check', 'test-script', 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "test-script.ps1" blue', '10')
+            self.deployment.consul_api.register_script_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_check', 'test-script', 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file test-script.ps1 blue', '10')
 
     @patch('os.stat')
     @patch('os.chmod')

--- a/tests/test_consul_healthchecks.py
+++ b/tests/test_consul_healthchecks.py
@@ -34,6 +34,7 @@ class MockDeployment(object):
     def __init__(self):
         self.logger = MockLogger()
         self.archive_dir = ''
+        self.platform = 'linux'
         self.appspec = {
             'healthchecks': healthchecks
         }
@@ -45,10 +46,14 @@ class MockDeployment(object):
                 check_id: check
             }
         }
+
     def set_checks(self, checks):
         self.appspec = {
             'consul_healthchecks': checks
         }
+
+    def set_platform(self, platform):
+        self.platform = platform
 
 
 class TestHealthChecks(unittest.TestCase):
@@ -143,6 +148,37 @@ class TestHealthChecks(unittest.TestCase):
         with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
             self.tested_fn._run(self.deployment)
             self.deployment.consul_api.register_script_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_check', 'test-script', 'test-script.py blue', '10')
+
+    @patch('os.stat')
+    @patch('os.chmod')
+    @patch('os.path.exists', return_value=True)
+    def test_windows_script_check_registration(self, stat, chmod, exists):
+        checks = {
+            'test_check': self.create_check(True, 'test-script', 'test-script.ps1', '10')
+        }
+        self.deployment.set_checks(checks)
+        self.deployment.consul_api = MagicMock()
+        self.deployment.set_platform('windows')
+
+        with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
+                self.tested_fn._run(self.deployment)
+                self.deployment.consul_api.register_script_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_check', 'test-script', 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "test-script.ps1"', '10')
+
+    @patch('os.stat')
+    @patch('os.chmod')
+    @patch('os.path.exists', return_value=True)
+    def test_windows_script_check_registration_with_slice(self, stat, chmod, exists):
+        checks = {
+            'test_check': self.create_check(True, 'test-script', 'test-script.ps1', '10')
+        }
+        self.deployment.set_checks(checks)
+        self.deployment.service.set_slice('blue')
+        self.deployment.consul_api = MagicMock()
+        self.deployment.set_platform('windows')
+
+        with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
+            self.tested_fn._run(self.deployment)
+            self.deployment.consul_api.register_script_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_check', 'test-script', 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "test-script.ps1" blue', '10')
 
     @patch('os.stat')
     @patch('os.chmod')

--- a/tests/test_sensu_healthchecks.py
+++ b/tests/test_sensu_healthchecks.py
@@ -320,7 +320,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "foo.ps1"')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "foo.ps1"')
 
     def test_generate_windows_check_definition_with_command_and_none_slice_and_no_arguments(self):
         check = {
@@ -330,7 +330,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'none'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "foo.ps1"')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "foo.ps1"')
     
     def test_generate_windows_check_definition_with_command_and_arguments(self):
         check = {
@@ -340,7 +340,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
     
     def test_generate_local_check_definition_with_command_and_arguments_and_slice(self):
         check = {
@@ -351,7 +351,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['local_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name green')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name green')
     
     def test_generate_server_check_definition_with_command_and_arguments_and_slice(self):
         check = {
@@ -362,4 +362,4 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')

--- a/tests/test_sensu_healthchecks.py
+++ b/tests/test_sensu_healthchecks.py
@@ -320,7 +320,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "foo.ps1"')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file foo.ps1')
 
     def test_generate_windows_check_definition_with_command_and_none_slice_and_no_arguments(self):
         check = {
@@ -330,7 +330,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'none'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "foo.ps1"')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file foo.ps1')
     
     def test_generate_windows_check_definition_with_command_and_arguments(self):
         check = {
@@ -340,7 +340,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1 -ServiceName service_name')
     
     def test_generate_local_check_definition_with_command_and_arguments_and_slice(self):
         check = {
@@ -351,7 +351,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['local_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name green')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1 -ServiceName service_name green')
     
     def test_generate_server_check_definition_with_command_and_arguments_and_slice(self):
         check = {
@@ -362,4 +362,4 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -file C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1 -ServiceName service_name')


### PR DESCRIPTION
Invalid `healthchecks.yml` files cause the agent to raise an exception and prevent installation from proceeding. In the case of deregistering and invalid `yml` file from a previous deployment, this can prevent any future deployments from succeeding.

This change catches *only* validation errors and will skip check registration/deregistration in these cases, allowing "fixing forward" deployments to succeed while still preventing installations that might result in an unknown state.