### PR TITLE
Bug/powershell error status

### DIFF
--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -61,7 +61,7 @@ class RegisterSensuHealthChecks(DeploymentStage):
 
         def get_command():
             if platform == 'windows':
-                command = 'powershell get-content "{0}" | powershell -noprofile -'.format(script_absolute_path)
+                command = 'powershell get-content "{0}" | powershell -noninteractive -noprofile -'.format(script_absolute_path)
             else:
                 command = script_absolute_path
             

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -61,7 +61,7 @@ class RegisterSensuHealthChecks(DeploymentStage):
 
         def get_command():
             if platform == 'windows':
-                command = 'powershell get-content "{0}" | powershell -noninteractive -noprofile -'.format(script_absolute_path)
+                command = 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "{0}"'.format(script_absolute_path)
             else:
                 command = script_absolute_path
             

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -61,7 +61,7 @@ class RegisterSensuHealthChecks(DeploymentStage):
 
         def get_command():
             if platform == 'windows':
-                command = '{0} "{1}"'.format('powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file', script_absolute_path)
+                command = 'powershell get-content "{0}" | powershell -noprofile -'.format(script_absolute_path)
             else:
                 command = script_absolute_path
             

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -61,7 +61,7 @@ class RegisterSensuHealthChecks(DeploymentStage):
 
         def get_command():
             if platform == 'windows':
-                command = 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "{0}"'.format(script_absolute_path)
+                command = 'powershell -noprofile -noninteractive -executionpolicy bypass -command "{0}"'.format(script_absolute_path)
             else:
                 command = script_absolute_path
             

--- a/tests/test_sensu_healthchecks.py
+++ b/tests/test_sensu_healthchecks.py
@@ -320,7 +320,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell get-content "foo.ps1" | powershell -noninteractive -noprofile -')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "foo.ps1"')
 
     def test_generate_windows_check_definition_with_command_and_none_slice_and_no_arguments(self):
         check = {
@@ -330,7 +330,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'none'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell get-content "foo.ps1" | powershell -noninteractive -noprofile -')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "foo.ps1"')
     
     def test_generate_windows_check_definition_with_command_and_arguments(self):
         check = {
@@ -340,7 +340,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell get-content "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" | powershell -noninteractive -noprofile - -ServiceName service_name')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
     
     def test_generate_local_check_definition_with_command_and_arguments_and_slice(self):
         check = {
@@ -351,7 +351,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['local_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell get-content "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" | powershell -noninteractive -noprofile - -ServiceName service_name green')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name green')
     
     def test_generate_server_check_definition_with_command_and_arguments_and_slice(self):
         check = {
@@ -362,4 +362,4 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell get-content "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" | powershell -noninteractive -noprofile - -ServiceName service_name')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')

--- a/tests/test_sensu_healthchecks.py
+++ b/tests/test_sensu_healthchecks.py
@@ -320,7 +320,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "foo.ps1"')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy bypass -command "foo.ps1"')
 
     def test_generate_windows_check_definition_with_command_and_none_slice_and_no_arguments(self):
         check = {
@@ -330,7 +330,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'none'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "foo.ps1"')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy bypass -command "foo.ps1"')
     
     def test_generate_windows_check_definition_with_command_and_arguments(self):
         check = {
@@ -340,7 +340,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy bypass -command "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
     
     def test_generate_local_check_definition_with_command_and_arguments_and_slice(self):
         check = {
@@ -351,7 +351,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['local_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name green')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy bypass -command "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name green')
     
     def test_generate_server_check_definition_with_command_and_arguments_and_slice(self):
         check = {
@@ -362,4 +362,4 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy unrestricted -command "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell -noprofile -noninteractive -executionpolicy bypass -command "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')

--- a/tests/test_sensu_healthchecks.py
+++ b/tests/test_sensu_healthchecks.py
@@ -320,7 +320,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "foo.ps1"')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell get-content "foo.ps1" | powershell -noninteractive -noprofile -')
 
     def test_generate_windows_check_definition_with_command_and_none_slice_and_no_arguments(self):
         check = {
@@ -330,7 +330,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'none'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "foo.ps1"')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell get-content "foo.ps1" | powershell -noninteractive -noprofile -')
     
     def test_generate_windows_check_definition_with_command_and_arguments(self):
         check = {
@@ -340,7 +340,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
             'interval': 10
         }
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell get-content "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" | powershell -noninteractive -noprofile - -ServiceName service_name')
     
     def test_generate_local_check_definition_with_command_and_arguments_and_slice(self):
         check = {
@@ -351,7 +351,7 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['local_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name green')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell get-content "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" | powershell -noninteractive -noprofile - -ServiceName service_name green')
     
     def test_generate_server_check_definition_with_command_and_arguments_and_slice(self):
         check = {
@@ -362,4 +362,4 @@ class TestRegisterSensuHealthChecks(unittest.TestCase):
         }
         self.deployment.service.slice = 'green'
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, check['server_script'], self.deployment)
-        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -file "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" -ServiceName service_name')
+        self.assertEqual(check_definition['checks']['sensu-check1']['command'], 'powershell get-content "C:\\Programs Files (x86)\\Sensu\\plugins\\check-windows-service.ps1" | powershell -noninteractive -noprofile - -ServiceName service_name')


### PR DESCRIPTION
Using "-Command" rather than "-File" seems like the cleanest way to keep the current execution policy expectations, parameter passing and error level reporting intact without creating a mess. 

This has been tested on Windows 10 VM Command Prompt and Ubuntu ZSH running powershell. Both report the error level 1 from a script that reads like this: 

    throw "I am broken"

There will be issues with "-Command" not reporting parseerror values back up to the top level - this seems like an acceptable solution to me. Users can be told to add the following to their scripts if they want to handle errors neatly: 

    trap 
    {
        write-error $_
        exit 1
    }