### PR TITLE
Feature/update sensu check filename convention

### DIFF
--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -5,7 +5,7 @@ from jsonschema import Draft4Validator
 from .common import DeploymentError, DeploymentStage, find_healthchecks, get_previous_deployment_appspec, wrap_script_command
 from .schemas import SensuHealthCheckSchema
 
-def create_sensu_check_definition_filename(service_id, check_id, environment='', service='', slice='', version=''):
+def create_sensu_check_definition_filename(service_id, check_id, environment='none', service='none', slice='none', version='none'):
     return '{0}-{1}-{2}-{3}-{4}-{5}.json'.format(service_id, check_id, environment, service, slice, version)
 
 class DeregisterOldSensuHealthChecks(DeploymentStage):

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -5,8 +5,8 @@ from jsonschema import Draft4Validator
 from .common import DeploymentError, DeploymentStage, find_healthchecks, get_previous_deployment_appspec, wrap_script_command
 from .schemas import SensuHealthCheckSchema
 
-def create_sensu_check_definition_filename(service_id, check_id):
-    return '{0}-{1}.json'.format(service_id, check_id)
+def create_sensu_check_definition_filename(service_id, check_id, environment, service, slice, version):
+    return '{0}-{1}-{2}-{3}-{4}-{5}.json'.format(service_id, check_id, environment, service, slice, version)
 
 class DeregisterOldSensuHealthChecks(DeploymentStage):
     def __init__(self):
@@ -27,7 +27,7 @@ class DeregisterOldSensuHealthChecks(DeploymentStage):
                     return
                 for check_id, check in healthchecks.iteritems():
                     deployment.logger.debug('Looking for sensu check: {0}'.format(check_id))
-                    check_definition_absolute_path = os.path.join(deployment.sensu['sensu_check_path'], create_sensu_check_definition_filename(deployment.service.id, check_id))
+                    check_definition_absolute_path = os.path.join(deployment.sensu['sensu_check_path'], create_sensu_check_definition_filename(deployment.service.id, check_id, deployment._environment.environment_name, deployment.service.name, deployment.service.slice, deployment.slice.version))
                     if os.path.exists(check_definition_absolute_path):
                         deployment.logger.info('Removing healthcheck: {0}'.format(check_definition_absolute_path))
                         os.remove(check_definition_absolute_path)
@@ -147,7 +147,7 @@ class RegisterSensuHealthChecks(DeploymentStage):
         deployment.logger.debug('Sensu check {0} script path: {1}'.format(check_id, script_absolute_path))
 
         check_definition = RegisterSensuHealthChecks.generate_check_definition(check, script_absolute_path, deployment)
-        check_definition_filename = create_sensu_check_definition_filename(deployment.service.id, check_id)
+        check_definition_filename = create_sensu_check_definition_filename(deployment.service.id, check_id, deployment._environment.environment_name, deployment.service.name, deployment.service.slice, deployment.service.version)
         check_definition_absolute_path = os.path.join(deployment.sensu['sensu_check_path'], check_definition_filename)
         is_success = RegisterSensuHealthChecks.write_check_definition_file(check_definition, check_definition_absolute_path, deployment)
         if not is_success:

--- a/agent/deployment_stages/sensu_healthchecks.py
+++ b/agent/deployment_stages/sensu_healthchecks.py
@@ -5,7 +5,7 @@ from jsonschema import Draft4Validator
 from .common import DeploymentError, DeploymentStage, find_healthchecks, get_previous_deployment_appspec, wrap_script_command
 from .schemas import SensuHealthCheckSchema
 
-def create_sensu_check_definition_filename(service_id, check_id, environment, service, slice, version):
+def create_sensu_check_definition_filename(service_id, check_id, environment='', service='', slice='', version=''):
     return '{0}-{1}-{2}-{3}-{4}-{5}.json'.format(service_id, check_id, environment, service, slice, version)
 
 class DeregisterOldSensuHealthChecks(DeploymentStage):


### PR DESCRIPTION
Requirement: Sensu check file names should include Environment, Service, Slice and version.

- Environment added to check definition file name
- Service added to check definition file name
- Slice added to check definition file name
- Version added to check definition file name

Ignored: To ensure that health checks a not left dangling we want to ensure that each service deployment overwrites any previous checks for that service.

- Separate ticket has been created for this _issue_