### PR TITLE
check that the app spec doesn't return NoneType for the hooks property

### DIFF
--- a/agent/deployment_stages/validate_bundle.py
+++ b/agent/deployment_stages/validate_bundle.py
@@ -20,15 +20,16 @@ class ValidateBundle(DeploymentStage):
             for permission in deployment.appspec.get('permissions', []):
                 if 'object' not in permission:
                     raise DeploymentError('Invalid appspec.yml: Contains permission definition with missing object. Permission definition: {0}'.format(permission))
-            for hook_name, definition in deployment.appspec.get('hooks', {}).iteritems():
-                if 'location' not in definition[0] or not definition[0]['location']:
-                    raise DeploymentError('Invalid appspec.yml: Contains hook \'{0}\' definition with missing location. Hook definition: {1}'.format(hook_name, definition))
-                location = definition[0]['location']
-                if location.startswith('/'):
-                    location = location[1:]
-                filepath = os.path.join(deployment.archive_dir, location)
-                if not os.path.isfile(filepath):
-                    raise DeploymentError('Invalid appspec.yml: Could not find deployment script \'{0}\' make certain it does exist'.format(definition[0]['location']))
+            if deployment.appspec.get('hooks', {}) is not None:        
+                for hook_name, definition in deployment.appspec.get('hooks', {}).iteritems():
+                    if 'location' not in definition[0] or not definition[0]['location']:
+                        raise DeploymentError('Invalid appspec.yml: Contains hook \'{0}\' definition with missing location. Hook definition: {1}'.format(hook_name, definition))
+                    location = definition[0]['location']
+                    if location.startswith('/'):
+                        location = location[1:]
+                    filepath = os.path.join(deployment.archive_dir, location)
+                    if not os.path.isfile(filepath):
+                        raise DeploymentError('Invalid appspec.yml: Could not find deployment script \'{0}\' make certain it does exist'.format(definition[0]['location']))
         deployment.logger.debug('Loading appspec file from {0}.' .format(os.path.join(deployment.archive_dir, 'appspec.yml')))
         appspec_stream = file(os.path.join(deployment.archive_dir, 'appspec.yml'), 'r')
         deployment.appspec = yaml.load(appspec_stream)


### PR DESCRIPTION
appspec.get('hooks') has been shown to return a NoneType which throws. It not checks the return value of the call to get first to make sure it is not working with NoneType when asking for iteritems(). 