### PR TITLE
Improve logging on script failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- No output returned when a script does not complete before its timeout.
+
 ## [2.1.7] 2017-11-02
 
 ### Changed
@@ -37,7 +43,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - "No such file or directory" error when copying files during application installation.
 - No port number selected for non blue/green deployments.
 
-[Unreleased]: https://github.com/trainline/consul-deployment-agent/compare/2.1.4...HEAD
+[Unreleased]: https://github.com/trainline/consul-deployment-agent/compare/2.1.7...HEAD
 [2.1.4]: https://github.com/trainline/consul-deployment-agent/compare/2.1.3...2.1.4
 [2.1.3]: https://github.com/trainline/consul-deployment-agent/compare/2.1.2...2.1.3
 [2.1.2]: https://github.com/trainline/consul-deployment-agent/compare/2.1.1...2.1.2

--- a/tests/test_deployment_scripts.ps1
+++ b/tests/test_deployment_scripts.ps1
@@ -1,0 +1,3 @@
+Write-Output 'Started'
+Start-Sleep -Seconds 3
+Write-Output 'Finished'

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -1,0 +1,47 @@
+# Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
+
+from os import linesep, path
+from platform import system
+from string import rsplit
+from unittest import TestCase
+from mock import MagicMock
+from agent.deployment_stages.deployment_scripts import PowershellScript, ShellScript
+
+CREATE_SCRIPT = PowershellScript if system() == 'Windows' else ShellScript
+SCRIPT_EXT = '.ps1' if system() == 'Windows' else '.sh'
+
+def with_script_ext(filename):
+    return filename + SCRIPT_EXT
+
+def relative(filename):
+    fullpath = path.join(path.dirname(__file__), filename)
+    print(fullpath)
+    return fullpath
+
+def from_file(filename):
+    return relative(with_script_ext(filename))
+
+class TestDeploymentScripts(TestCase):
+
+    def test_returns_partial_output_after_timeout(self):
+        script = CREATE_SCRIPT(from_file('test_deployment_scripts'), timeout=2)
+        logger = MagicMock()
+        exit_code, stdout = script.execute(logger)
+        self.assertNotEqual(exit_code, 0)
+        self.assertEqual(stdout, 'Started' + linesep)
+
+    def test_returns_full_output_after_completion(self):
+        script = CREATE_SCRIPT(from_file('test_deployment_scripts'), timeout=5)
+        logger = MagicMock()
+        exit_code, stdout = script.execute(logger)
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, 'Started' + linesep + 'Finished' + linesep)
+
+    def test_returns_big_output(self):
+        script = CREATE_SCRIPT(from_file('test_deployment_scripts_big_output'), timeout=10)
+        logger = MagicMock()
+        result = script.execute(logger)
+        _, stdout = result
+        [_, last] = rsplit(stdout, maxsplit=1)
+        self.assertEqual(last, 'Finished')
+

--- a/tests/test_deployment_scripts.sh
+++ b/tests/test_deployment_scripts.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo 'Started'
+sleep 3
+echo 'Finished'

--- a/tests/test_deployment_scripts_big_output.ps1
+++ b/tests/test_deployment_scripts_big_output.ps1
@@ -1,0 +1,2 @@
+1..10000 | foreach { Write-Output (1..80 -join ', ') }
+Write-Output 'Finished'

--- a/tests/test_deployment_scripts_big_output.sh
+++ b/tests/test_deployment_scripts_big_output.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for i in `seq 1 10000`; do
+    seq -s ', ' 1 80
+done
+echo 'Finished'


### PR DESCRIPTION
* Return the output of the process even if it is killed by a timeout
* Avoid use of `Popen.stdout.read` as recommended in the [Python documentation](https://docs.python.org/2/library/subprocess.html#subprocess.Popen.communicate)
* Remove polling of child process (`Popen.communicate()` will wait until the process terminates)

https://jira.thetrainline.com/browse/PLATFORM-5863