### PR TITLE
Fix recursive file copy failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- "No such file or directory" error when copying files during application installation.
+
+[Unreleased]: https://github.com/trainline/consul-deployment-agent/compare/2.1.0...HEAD

--- a/agent/deployment_stages/copy_files.py
+++ b/agent/deployment_stages/copy_files.py
@@ -1,6 +1,7 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-import distutils.core, os
+import os
+import shutil
 from .common import DeploymentStage
 
 class CopyFiles(DeploymentStage):
@@ -11,7 +12,7 @@ class CopyFiles(DeploymentStage):
             for file in files:
                 if os.path.isdir(file['destination']):
                     deployment.logger.debug('Destination {0} already exists, cleaning up first.'.format(file['destination']))
-                    distutils.dir_util.remove_tree(file['destination'])
+                    shutil.rmtree(file['destination'])
         def copy_files(files, logger):
             for file in deployment.appspec.get('files', []):
                 if file['source'].startswith('/'):
@@ -20,13 +21,13 @@ class CopyFiles(DeploymentStage):
                     source = os.path.join(deployment.archive_dir, file['source'])
                 if os.path.isdir(source):
                     deployment.logger.debug('Moving content of {0} directory recursively to {1}.'.format(source, file['destination']))
-                    distutils.dir_util.copy_tree(source, file['destination'])
+                    shutil.copytree(source, file['destination'])
                 else:
                     if not os.path.isdir(file['destination']):
                         deployment.logger.debug('Creating missing directory {0}.'.format(file['destination']))
-                        distutils.dir_util.mkpath(file['destination'])
+                        os.makedirs(file['destination'])
                     deployment.logger.debug('Moving file {0} to {1}.'.format(source, file['destination']))
-                    distutils.file_util.copy_file(source, file['destination'])
+                    shutil.copy(source, file['destination'])
         if 'files' not in deployment.appspec:
             deployment.logger.info('Skipping CopyFiles stage as there are no file operations defined in appspec.yml.')
             return

--- a/agent/deployment_stages/delete_previous_deployment_files.py
+++ b/agent/deployment_stages/delete_previous_deployment_files.py
@@ -1,6 +1,8 @@
 # Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-import distutils.core, os
+import os
+import shutil
+from traceback import format_exception
 from .common import DeploymentStage
 
 class DeletePreviousDeploymentFiles(DeploymentStage):
@@ -11,7 +13,10 @@ class DeletePreviousDeploymentFiles(DeploymentStage):
             deployment.logger.info('Skipping {0} stage as there is no previous deployment.'.format(self.name))
         else:
             if os.path.isdir(deployment.last_dir):
+                def remove_failed(function, path, excinfo):
+                    err_msg = ''.join(format_exception(*excinfo, limit = 1))
+                    deployment.logger.warning('Failed to delete {0}. {1}'.format(path, err_msg))
                 deployment.logger.info('Deleting directory of previous deployment {0}.'.format(deployment.last_dir))
-                distutils.dir_util.remove_tree(deployment.last_dir)
+                shutil.rmtree(deployment.last_dir)
             else:
                 deployment.logger.warning('The directory of last deployment doesn\'t exist {0}.'.format(deployment.last_dir))


### PR DESCRIPTION
This PR fixes a recursive file copy failure during application installation. A representative log entry is shown below. The error is caused by the use of `distutils` to perform the copy operation. This fix replaces it with `shutil` as recommended at https://bugs.python.org/issue22132.

```
[2017-09-12 00:00:00,000] [ERROR] [Errno 2] No such file or directory: u'/opt/my/app/some/file.js'
Traceback (most recent call last):
  File "agent/deployment_stages/common.py", line 19, in run
  File "agent/deployment_stages/copy_files.py", line 34, in _run
  File "agent/deployment_stages/copy_files.py", line 23, in copy_files
  File "distutils/dir_util.py", line 163, in copy_tree
  File "distutils/dir_util.py", line 163, in copy_tree
  File "distutils/dir_util.py", line 167, in copy_tree
  File "distutils/file_util.py", line 148, in copy_file
  File "distutils/file_util.py", line 44, in _copy_file_contents
```

https://jira.thetrainline.com/browse/PLATFORM-6264