### PR TITLE
Copy content of multiple source directories to the same destination directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Fixed
+- Unable to copy the contents of multiple directories to one target directory using the `files` section of `appspec.yaml`.
+
 ## [2.1.1] 2017-09-12
 
 ### Fixed

--- a/agent/deployment_stages/copy_files.py
+++ b/agent/deployment_stages/copy_files.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+from agent.tweaked_shutil import mergetree
 from .common import DeploymentStage
 
 class CopyFiles(DeploymentStage):
@@ -21,7 +22,7 @@ class CopyFiles(DeploymentStage):
                     source = os.path.join(deployment.archive_dir, file['source'])
                 if os.path.isdir(source):
                     deployment.logger.debug('Moving content of {0} directory recursively to {1}.'.format(source, file['destination']))
-                    shutil.copytree(source, file['destination'])
+                    mergetree(source, file['destination'])
                 else:
                     if not os.path.isdir(file['destination']):
                         deployment.logger.debug('Creating missing directory {0}.'.format(file['destination']))

--- a/agent/tweaked_shutil.py
+++ b/agent/tweaked_shutil.py
@@ -1,0 +1,62 @@
+"""
+Destructive alternatives to functions in the shutil module.
+"""
+
+# Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
+
+from shutil import copy2, Error, copystat, os
+
+def mergetree(src, dst, symlinks=False, ignore=None):
+    """
+    Like shutil.copytree except it overwrites the destination
+
+    If dst does not exist it is created.
+
+    If dst exists but is not a directory it is repaced.
+
+    If dst exists and is a directory the files in src are copied to dst. If a file already exists in dst it is overwritten. The child directories of src are copied to dst by recursive calls to mergetree.
+
+    The implementation is adapted from the code for shutil.copytree at https://docs.python.org/2/library/shutil.html#copytree-example
+    """
+    names = os.listdir(src)
+    if ignore is not None:
+        ignored_names = ignore(src, names)
+    else:
+        ignored_names = set()
+
+    if os.path.exists(dst) and not os.path.isdir(dst):
+        os.remove(dst)
+    if not os.path.isdir(dst):
+        os.makedirs(dst)
+
+    errors = []
+    for name in names:
+        if name in ignored_names:
+            continue
+        srcname = os.path.join(src, name)
+        dstname = os.path.join(dst, name)
+        try:
+            if symlinks and os.path.islink(srcname):
+                linkto = os.readlink(srcname)
+                os.symlink(linkto, dstname)
+            elif os.path.isdir(srcname):
+                mergetree(srcname, dstname, symlinks, ignore)
+            else:
+                copy2(srcname, dstname)
+            # XXX What about devices, sockets etc.?
+        except (IOError, os.error) as why:
+            errors.append((srcname, dstname, str(why)))
+        # catch the Error from the recursive copytree so that we can
+        # continue with other files
+        except Error as err:
+            errors.extend(err.args[0])
+    try:
+        copystat(src, dst)
+    except WindowsError:
+        # can't copy file access times on Windows
+        pass
+    except OSError as why:
+        errors.extend((src, dst, str(why)))
+    if errors:
+        raise Error(errors)
+        

--- a/tests/test_tweaked_shutil.py
+++ b/tests/test_tweaked_shutil.py
@@ -1,0 +1,93 @@
+# Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
+
+import unittest
+import os
+import shutil
+import tempfile
+from os.path import join
+from agent.tweaked_shutil import mergetree
+
+def w(path, content):
+    with open(path, 'w') as f:
+        f.write(content)
+
+def r(path):
+    with open(path, 'r') as f:
+        return f.read()
+
+class TestCommonDeploymentStageUtils(unittest.TestCase):
+    def test_it_overwrites_a_file_with_the_same_name(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            indir = join(tmpdir, 'input')
+            outdir = join(tmpdir, 'output')
+            os.makedirs(indir)
+            w(join(indir, 'overwrite.txt'), 'success')
+            os.makedirs(outdir)
+            w(join(outdir, 'overwrite.txt'), 'should be overwritten')
+            mergetree(indir, outdir)
+            self.assertEqual(r(join(outdir, 'overwrite.txt')), 'success')
+        finally:
+            shutil.rmtree(tmpdir)
+    def test_it_overwrites_a_file_with_a_dir_of_the_same_name(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            indir = join(tmpdir, 'input')
+            outdir = join(tmpdir, 'output')
+            os.makedirs(indir)
+            os.makedirs(join(indir, 'overwrite'))
+            os.makedirs(outdir)
+            w(join(outdir, 'overwrite'), 'should be replaced by a dir')
+            mergetree(indir, outdir)
+            self.assertFalse(os.path.isfile(join(outdir, 'overwrite')))
+            self.assertTrue(os.path.isdir(join(outdir, 'overwrite')))
+        finally:
+            shutil.rmtree(tmpdir)
+    def test_it_does_not_modify_an_existing_file_without_a_name_collision(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            indir = join(tmpdir, 'input')
+            outdir = join(tmpdir, 'output')
+            os.makedirs(indir)
+            os.makedirs(outdir)
+            w(join(outdir, 'expected-file.txt'), 'success')
+            mergetree(indir, outdir)
+            self.assertTrue(os.path.isfile(join(outdir, 'expected-file.txt')))
+        finally:
+            shutil.rmtree(tmpdir)
+    def test_it_appends_a_file_not_already_present(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            indir = join(tmpdir, 'input')
+            outdir = join(tmpdir, 'output')
+            os.makedirs(indir)
+            w(join(indir, 'expected-file.txt'), 'success')
+            os.makedirs(outdir)
+            mergetree(indir, outdir)
+            self.assertTrue(os.path.isfile(join(outdir, 'expected-file.txt')))
+        finally:
+            shutil.rmtree(tmpdir)
+    def test_complex_scenario(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            indir = join(tmpdir, 'input')
+            outdir = join(tmpdir, 'output')
+            os.makedirs(join(indir, 'a'))
+            os.makedirs(join(indir, 'c'))
+            w(join(indir, 'a', 'a.txt'), 'a')
+            w(join(indir, 'c', 'a.txt'), 'aca')
+            w(join(indir, 'c', 'c.txt'), 'acc')
+            os.makedirs(outdir)
+            os.makedirs(join(outdir, 'b'))
+            os.makedirs(join(outdir, 'c'))
+            w(join(outdir, 'b', 'b.txt'), 'b')
+            w(join(outdir, 'c', 'b.txt'), 'bcb')
+            w(join(outdir, 'c', 'c.txt'), 'bcc')
+            mergetree(indir, outdir)
+            self.assertEqual(r(join(outdir, 'a', 'a.txt')), 'a')
+            self.assertEqual(r(join(outdir, 'b', 'b.txt')), 'b')
+            self.assertEqual(r(join(outdir, 'c', 'a.txt')), 'aca')
+            self.assertEqual(r(join(outdir, 'c', 'b.txt')), 'bcb')
+            self.assertEqual(r(join(outdir, 'c', 'c.txt')), 'acc')
+        finally:
+            shutil.rmtree(tmpdir)


### PR DESCRIPTION
Replace `shutil.copytree` with a custom module `mergetree` that overwrites any files already present in the destination directory and merges the contents of any directories already present in the destination directory.

https://jira.thetrainline.com/browse/PD-404