### PR TITLE
Add tls_skip_verify option to consul http healthchecks

### DIFF
--- a/agent/consul_api.py
+++ b/agent/consul_api.py
@@ -100,7 +100,7 @@ class ConsulApi(object):
         response = self._api_put('agent/check/deregister/{0}'.format(id), {})
         return response.status_code == 200
 
-    def register_http_check(self, service_id, id, name, url, tls_skip_verify, interval):
+    def register_http_check(self, service_id, id, name, url, interval, tls_skip_verify=False):
         response = self._api_put('agent/check/register', json.dumps({'ServiceID': service_id, 'ID': id, 'Name': name, 'HTTP': url, 'TLSSkipVerify': tls_skip_verify, 'Interval': interval}))
         return response.status_code == 200
 

--- a/agent/consul_api.py
+++ b/agent/consul_api.py
@@ -100,8 +100,8 @@ class ConsulApi(object):
         response = self._api_put('agent/check/deregister/{0}'.format(id), {})
         return response.status_code == 200
 
-    def register_http_check(self, service_id, id, name, url, interval):
-        response = self._api_put('agent/check/register', json.dumps({'ServiceID': service_id, 'ID': id, 'Name': name, 'HTTP': url, 'Interval': interval}))
+    def register_http_check(self, service_id, id, name, url, tls_skip_verify, interval):
+        response = self._api_put('agent/check/register', json.dumps({'ServiceID': service_id, 'ID': id, 'Name': name, 'HTTP': url, 'TLSSkipVerify': tls_skip_verify, 'Interval': interval}))
         return response.status_code == 200
 
     def register_script_check(self, service_id, id, name, script_path, interval):

--- a/agent/deployment_stages/consul_healthchecks.py
+++ b/agent/deployment_stages/consul_healthchecks.py
@@ -92,7 +92,7 @@ class RegisterConsulHealthChecks(DeploymentStage):
 
             elif check_type == HealthcheckTypes.HTTP:
                 check_url = HealthcheckUtils.get_http_url(check, deployment.service)
-                is_success = deployment.consul_api.register_http_check(deployment.service.id, service_check_id, check['name'], check_url, check['tls_skip_verify'], check['interval'])
+                is_success = deployment.consul_api.register_http_check(deployment.service.id, service_check_id, check['name'], check_url, check['interval'], check['tls_skip_verify'])
             else:
                 is_success = False
 

--- a/agent/deployment_stages/consul_healthchecks.py
+++ b/agent/deployment_stages/consul_healthchecks.py
@@ -92,7 +92,7 @@ class RegisterConsulHealthChecks(DeploymentStage):
 
             elif check_type == HealthcheckTypes.HTTP:
                 check_url = HealthcheckUtils.get_http_url(check, deployment.service)
-                is_success = deployment.consul_api.register_http_check(deployment.service.id, service_check_id, check['name'], check_url, check['interval'], check['tls_skip_verify'])
+                is_success = deployment.consul_api.register_http_check(deployment.service.id, service_check_id, check['name'], check_url, check['interval'], check.get('tls_skip_verify', False))
             else:
                 is_success = False
 

--- a/agent/deployment_stages/consul_healthchecks.py
+++ b/agent/deployment_stages/consul_healthchecks.py
@@ -92,7 +92,7 @@ class RegisterConsulHealthChecks(DeploymentStage):
 
             elif check_type == HealthcheckTypes.HTTP:
                 check_url = HealthcheckUtils.get_http_url(check, deployment.service)
-                is_success = deployment.consul_api.register_http_check(deployment.service.id, service_check_id, check['name'], check_url, check['interval'])
+                is_success = deployment.consul_api.register_http_check(deployment.service.id, service_check_id, check['name'], check_url, check['tls_skip_verify'], check['interval'])
             else:
                 is_success = False
 

--- a/tests/test_consul_api.py
+++ b/tests/test_consul_api.py
@@ -70,6 +70,13 @@ class TestConsulApi(unittest.TestCase):
         consul_api = ConsulApi(consul_config)
         is_success = consul_api.register_http_check('Ping', id='http_check', name='Ping', url='http://127.0.0.1:8080/ping', interval='10s')
         self.assertEqual(is_success, True)
+        
+    @responses.activate
+    def test_register_http_check_succeeds(self):
+        responses.add(responses.PUT, 'http://localhost:8500/v1/agent/check/register', status=200)
+        consul_api = ConsulApi(consul_config)
+        is_success = consul_api.register_http_check('Ping', id='http_check', name='Ping', url='http://127.0.0.1:8080/ping', tls_skip_verify=False, interval='10s')
+        self.assertEqual(is_success, True)
 
     @responses.activate
     def test_register_http_check_fails(self):

--- a/tests/test_consul_api.py
+++ b/tests/test_consul_api.py
@@ -72,10 +72,10 @@ class TestConsulApi(unittest.TestCase):
         self.assertEqual(is_success, True)
         
     @responses.activate
-    def test_register_http_check_succeeds(self):
+    def test_register_http_check_with_tls_skip_verify_on_succeeds(self):
         responses.add(responses.PUT, 'http://localhost:8500/v1/agent/check/register', status=200)
         consul_api = ConsulApi(consul_config)
-        is_success = consul_api.register_http_check('Ping', id='http_check', name='Ping', url='http://127.0.0.1:8080/ping', tls_skip_verify=False, interval='10s')
+        is_success = consul_api.register_http_check('Ping', id='http_check', name='Ping', url='http://127.0.0.1:8080/ping', tls_skip_verify=True, interval='10s')
         self.assertEqual(is_success, True)
 
     @responses.activate

--- a/tests/test_consul_healthchecks.py
+++ b/tests/test_consul_healthchecks.py
@@ -91,6 +91,31 @@ class TestHealthChecks(unittest.TestCase):
         with self.assertRaisesRegexp(DeploymentError, 'is missing field \'url\''):
             self.tested_fn._run(self.deployment)
 
+    def test_missing_http_tls_skip_verify_field(self):
+        check = {
+            'type': 'http',
+            'name': 'Missing tls_skip_verify',
+            'url': 'http://localhost',
+            'interval': 10
+        }
+        self.deployment.set_check('check_successful', check)
+        self.deployment.consul_api = MagicMock()
+        self.tested_fn._run(self.deployment)
+        self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:check_successful', 'Missing tls_skip_verify', 'http://localhost', 10, False)
+        
+    def test_http_tls_skip_verify_field(self):
+        check = {
+            'type': 'http',
+            'name': 'Test tls_skip_verify',
+            'url': 'http://localhost',
+            'interval': 10,
+            'tls_skip_verify': True
+        }
+        self.deployment.set_check('check_successful', check)
+        self.deployment.consul_api = MagicMock()
+        self.tested_fn._run(self.deployment)
+        self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:check_successful', 'Test tls_skip_verify', 'http://localhost', 10, True)
+
     def test_case_insensitive_id_conflict(self):
         checks = {
             'check_1': {

--- a/tests/test_consul_healthchecks.py
+++ b/tests/test_consul_healthchecks.py
@@ -187,14 +187,14 @@ class TestHealthChecks(unittest.TestCase):
     @patch('os.path.exists', return_value=True)
     def test_script_http_registration(self, stat, chmod, exists):
         checks = {
-            'test_http_check': self.create_check(False, 'test-http', 'http://acme.com/healthcheck', '20')
+            'test_http_check': self.create_check(False, 'test-http', 'http://acme.com/healthcheck', '20', False)
         }
         self.deployment.set_checks(checks)
         self.deployment.consul_api = MagicMock()
 
         with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
             self.tested_fn._run(self.deployment)
-            self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_http_check', 'test-http', 'http://acme.com/healthcheck', False, '20')
+            self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_http_check', 'test-http', 'http://acme.com/healthcheck', '20', False)
     @patch('os.stat')
     @patch('os.chmod')
     @patch('os.path.exists', return_value=True)
@@ -207,7 +207,7 @@ class TestHealthChecks(unittest.TestCase):
 
         with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
             self.tested_fn._run(self.deployment)
-            self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_http_check', 'test-http', 'http://acme.com/healthcheck', True, '20')
+            self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_http_check', 'test-http', 'http://acme.com/healthcheck', '20', True)
     
     @patch('os.stat')
     @patch('os.chmod')
@@ -222,7 +222,7 @@ class TestHealthChecks(unittest.TestCase):
         with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
             self.tested_fn._run(self.deployment)
             expected_url = 'http://localhost:{0}/service/api'.format(MOCK_PORT)
-            self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_http_check', 'test-http', expected_url, False, '20')
+            self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_http_check', 'test-http', expected_url, '20', False)
     
     @patch('os.stat')   
     @patch('os.chmod')
@@ -238,9 +238,9 @@ class TestHealthChecks(unittest.TestCase):
         # Slice value should not affect http value
         with patch('agent.deployment_stages.consul_healthchecks.find_healthchecks', return_value=(checks, '')):
             self.tested_fn._run(self.deployment)
-            self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_http_check', 'test-http', 'http://acme.com/healthcheck', False, '20')
+            self.deployment.consul_api.register_http_check.assert_called_once_with('my-mock-service', 'my-mock-service:test_http_check', 'test-http', 'http://acme.com/healthcheck', '20', False)
     
-    def create_check(self, is_script, name, value, interval, tls_skip_verify):
+    def create_check(self, is_script, name, value, interval, tls_skip_verify=False):
         check = { 'name':name, 'interval':interval }
         if is_script:
             check['type'] = 'script'


### PR DESCRIPTION
Expose the `tls_skip_verify` property on [consul http checks](https://www.consul.io/docs/agent/checks.html#check-definition).

Currently you cannot define an http healthcheck for a `https://localhost/...` endpoint since certificate validation will fail.  Exposing this option enables certificate validation to be bypassed solely for the purposes of this check.

By default, if `tls_skip_verify` is not specified in `healthchecks.yml`, then the existing behaviour (certificate validation on) is preserved.