### PR TITLE
Always run stop application stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint: init init-lint
 	pyflakes .
 
 test: init init-test
-	nosetests --verbosity=2 tests
+	nosetests --verbosity=2 tests/*
 
 test-windows-deployment: init init-test
 	nosetests --verbosity=2 tests/test_deployment_windows.py

--- a/tests/scripts/write_a_lot_to_stdout.sh
+++ b/tests/scripts/write_a_lot_to_stdout.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-
+#!/usr/bin/env bash
 for i in `seq 1 1000`; do
     seq -s ', ' 1 80
 done

--- a/tests/test_running_stop_application_script.py
+++ b/tests/test_running_stop_application_script.py
@@ -1,0 +1,85 @@
+# Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information.
+
+import unittest
+from agent.deployment import run_stages
+
+
+class TestStopApplicationStageIsCalledInEventOfFailure(unittest.TestCase):
+    def setUp(self):
+        self.sut = run_stages
+        self.stop_application = StopApplication()
+
+    def test_stop_is_run_when_EARLIER_stage_fails(self):
+        self.sut([GoesBang(), self.stop_application],
+                 object(), Reporter().method, Logger())
+
+        self.assertTrue(self.stop_application.verify())
+        self.assertEquals(self.stop_application.executed_count, 1)
+
+    def test_stop_is_run_when_LATER_stage_fails(self):
+        self.stop_application = StopApplication(2)
+        self.sut([Works(), self.stop_application, GoesBang()],
+                 object(), Reporter().method, Logger())
+
+        self.assertTrue(self.stop_application.verify())
+
+    def test_when_nothing_fails_stop_stage_is_run(self):
+        self.sut([Works(), Works(), Works(), self.stop_application, Works(), Works()],
+                 object(), Reporter().method, Logger())
+
+        self.assertTrue(self.stop_application.verify())
+        self.assertEquals(self.stop_application.executed_count, 1)
+
+
+###########
+# HELPERS #
+###########
+
+class GoesBang():
+    def __init__(self):
+        self.name = "failing"
+
+    def run(self, deployment):
+        return False
+
+
+class Works():
+    def __init__(self):
+        self.name = "working"
+
+    def run(self, deployment):
+        return True
+
+
+class StopApplication():
+    def __init__(self, execution_count_expectation=1):
+        self.name = "StopApplication"
+        self.has_run = False
+        self.execution_count_expectation = execution_count_expectation
+        self.executed_count = 0
+
+    def run(self, deployment):
+        self.executed_count = self.executed_count + 1
+        self.has_run = True
+        return True
+
+    def verify(self):
+        print self.has_run
+        print self.executed_count
+        if self.has_run == True and self.executed_count == self.execution_count_expectation:
+            return True
+        else:
+            return False
+
+
+class Logger():
+    def error(self, string):
+        pass
+
+    def info(self, string):
+        pass
+
+
+class Reporter():
+    def method(self, string):
+        pass


### PR DESCRIPTION
- Tests were not running on my windows machine so changed the make file to allow this.
- Some formatting changes as a result of pylint.
- Tests added to cover new use case of the CDA -> if the deployment fails, the stop application script should always be run. 